### PR TITLE
[N/A] Date serialisation fix

### DIFF
--- a/OpenFin.Notifications/DateTimeConverter.cs
+++ b/OpenFin.Notifications/DateTimeConverter.cs
@@ -1,0 +1,54 @@
+﻿using Newtonsoft.Json;
+using System;
+
+namespace OpenFin.Notifications
+{
+    /**
+     * Serailizes DateTime objects into integer JavaScript timestamps.
+     * 
+     * Based on https://github.com/JamesNK/Newtonsoft.Json/blob/master/Src/Newtonsoft.Json/Utilities/DateTimeUtils.cs
+     */
+    public class DateTimeConverter : JsonConverter
+    {
+        internal static readonly long InitialJavaScriptDateTicks = 621355968000000000;
+
+        public override bool CanConvert(Type objectType)
+        {
+            return true;
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            if (reader.TokenType == JsonToken.Integer)
+            {
+                long javaScriptTicks = serializer.Deserialize<long>(reader);
+                long ticks = (javaScriptTicks * 10000) + InitialJavaScriptDateTicks;
+
+                return new DateTime(ticks);
+            }
+            else if (reader.TokenType == JsonToken.Null)
+            {
+                return null;
+            }
+            else
+            {
+                throw new Exception("Must be an integer or null");
+            }
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            if (value is DateTime)
+            {
+                long ticks = ((DateTime)value).ToUniversalTime().Ticks;
+                long javaScriptTicks = (ticks - InitialJavaScriptDateTicks) / 10000;
+
+                serializer.Serialize(writer, javaScriptTicks);
+            }
+            else
+            {
+                throw new Exception("Must be a DateTime object");
+            }
+        }
+    }
+}

--- a/OpenFin.Notifications/NotificationOptions.cs
+++ b/OpenFin.Notifications/NotificationOptions.cs
@@ -63,6 +63,7 @@ namespace OpenFin.Notifications
         /// The Timestanp displayed in the notification (default is the current date/time)
         /// </summary>
         [JsonProperty("date")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime Date { get; set; } = DateTime.Now;
 
         /// <summary>
@@ -75,6 +76,7 @@ namespace OpenFin.Notifications
         /// The expiration date and time of the notfication. If not specified, notification will persist until explicity closed.
         /// </summary>
         [JsonProperty("expires")]
+        [JsonConverter(typeof(DateTimeConverter))]
         public DateTime? Expires { get; set; }
     }
 }

--- a/OpenFin.Notifications/OpenFin.Notifications.csproj
+++ b/OpenFin.Notifications/OpenFin.Notifications.csproj
@@ -60,6 +60,7 @@
     <Compile Include="Constants\NotificationEventTypes.cs" />
     <Compile Include="Constants\ServiceConstants.cs" />
     <Compile Include="ButtonOptions.cs" />
+    <Compile Include="DateTimeConverter.cs" />
     <Compile Include="NotificationClient.cs" />
     <Compile Include="Constants\Topics.cs" />
     <Compile Include="NotificationEvent.cs" />


### PR DESCRIPTION
Added custom serialiser for DateTime objects sent between client and provider. Provider expects dates to be serialised as JS integer timestamps, default NewtonSoft behaviour is to stringify in a non-JS format.